### PR TITLE
+1 byte for the NUL-terminator

### DIFF
--- a/exercism/hello-world/hello_world.c
+++ b/exercism/hello-world/hello_world.c
@@ -4,10 +4,12 @@
 
 const char *hello(void)
 {
-    char * ans = malloc(sizeof(char) * strlen("Hello, World!"));
-    if (!ans) return NULL;
-    strcpy(ans,"Hello, World!");
-
-    /* string is pointer of the first character */
+    char * ans = malloc(sizeof(char) * strlen("Hello, World!") + 1); /* Allocate as many bytes as needed +1 for the NUL-terminator*/
+    if (!ans) {
+        return NULL;
+    }
+    
+    strcpy(ans, "Hello, World!");
+    
     return  ans;
 }


### PR DESCRIPTION
Fixed a critical flaw where `strcpy` would write the final NUL-terminator in an invalid location invoking Undefined Behavior. Allocated one extra byte to fix it.

Cleaned up the code as well in the process